### PR TITLE
グラフに同一の都道府県が重複する問題を修正

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,11 +19,6 @@ function App() {
       }))
     )
   }, [prefs])
-  useEffect(() => {
-    setDisplay(
-      checked.filter((elm) => elm.checked).map((elm) => elm.prefucture)
-    )
-  }, [checked])
   return (
     <div>
       <Header />
@@ -41,6 +36,15 @@ function App() {
                   e
                 ].sort((a, b) => a.prefucture.prefCode - b.prefucture.prefCode)
               )
+              if (e.checked) {
+                setDisplay([...display, e.prefucture])
+              } else {
+                setDisplay(
+                  display.filter(
+                    (pref) => pref.prefCode !== e.prefucture.prefCode
+                  )
+                )
+              }
               return
             }}
           />

--- a/src/components/PrefsPopulationChart.tsx
+++ b/src/components/PrefsPopulationChart.tsx
@@ -41,7 +41,10 @@ export default function PrefsPopulationChart({ populations }: Props) {
 
   return (
     <div>
-      <HighchartsReact highcharts={Highcharts} options={options} />
+      <HighchartsReact
+        highcharts={Highcharts}
+        options={options}
+      />
     </div>
   )
 }

--- a/src/hooks/areas.ts
+++ b/src/hooks/areas.ts
@@ -49,5 +49,5 @@ export function usePrefucturePopulation(prefuctures: Array<Prefucture>) {
       population: data[pref.prefCode] || []
     }
   })
-  return populations.filter((elm) => elm.population.length > 0)
+  return populations
 }

--- a/src/hooks/areas.ts
+++ b/src/hooks/areas.ts
@@ -1,5 +1,5 @@
 import { useEffect, useState, useRef } from 'react'
-import { PrefsPopulation, Prefucture } from '../types/areas.d'
+import { Population, Prefucture } from '../types/areas.d'
 import { AREAS_API_URL } from '../utils/config'
 
 // 都道府県の一覧
@@ -18,49 +18,36 @@ export function usePrefuctures() {
 
 // 都道府県のArrayを受け取って都道府県と人口の一覧を返す
 export function usePrefucturePopulation(prefuctures: Array<Prefucture>) {
-  const [populations, setPopulations] = useState<Array<PrefsPopulation>>([])
-  const populationsRef = useRef(populations)
-
+  const [data, setData] = useState<Array<Array<Population>>>([]) // ここにメモ化みたいなやつをする
+  const dataRef = useRef(data)
   useEffect(() => {
-    populationsRef.current = populations
-  }, [populations])
-
-  // APIを叩いて人口構成を取得し、populationsに追加
-  const fetchPopulation = async (prefucture: Prefucture) => {
-    const query = new URLSearchParams({
-      prefCode: prefucture.prefCode,
-      cityCode: '-'
-    } as unknown as Record<string, string>)
-    const res = await fetch(
-      AREAS_API_URL + '/api/v1/population/composition/perYear?' + query
-    )
-    const data = await res.json()
-
-    setPopulations([
-      ...populationsRef.current,
-      { prefucture: prefucture, population: data.result.data[0].data }
-    ])
-  }
+    dataRef.current = data
+  }, [data])
 
   // 都道府県のリストが変わった際の処理
   useEffect(() => {
-    // 消えたものを取り除く
-    setPopulations(
-      populationsRef.current.filter((elm) =>
-        prefuctures.map((e) => e.prefCode).includes(elm.prefucture.prefCode)
+    // APIを叩いて人口構成を取得し、populationsに追加
+    const fetchPopulation = async (prefucture: Prefucture) => {
+      if (dataRef.current[prefucture.prefCode]) return
+      const query = new URLSearchParams({
+        prefCode: prefucture.prefCode,
+        cityCode: '-'
+      } as unknown as Record<string, string>)
+      const res = await fetch(
+        AREAS_API_URL + '/api/v1/population/composition/perYear?' + query
       )
-    )
-    // 追加されたものを加える
-    prefuctures.forEach((pref) => {
-      if (
-        !populationsRef.current
-          .map((e) => e.prefucture.prefCode)
-          .includes(pref.prefCode)
-      ) {
-        console.log(prefuctures, pref)
-        fetchPopulation(pref)
-      }
-    })
-  }, [prefuctures])
-  return populations
+      const json = await res.json()
+      const tmp = { ...dataRef.current }
+      tmp[prefucture.prefCode] = json.result.data[0].data
+      setData(tmp)
+    }
+    prefuctures.forEach((pref) => fetchPopulation(pref))
+  }, [prefuctures, setData])
+  const populations = prefuctures.map((pref) => {
+    return {
+      prefucture: pref,
+      population: data[pref.prefCode] || []
+    }
+  })
+  return populations.filter((elm) => elm.population.length > 0)
 }


### PR DESCRIPTION
fetch中にチェックを外すと反映されず、表示に齟齬が出る問題を修正。
~~`usePrefucturePopulation`でfetch中の都道府県を返さないようにする。~~