### PR TITLE
スタイルの調整

### DIFF
--- a/src/components/LabeledCheckbox.tsx
+++ b/src/components/LabeledCheckbox.tsx
@@ -6,11 +6,13 @@ interface Props {
 }
 export default function LabeledCheckbox(props: Props) {
   return (
-    <div>
-      <label>
-        <input type="checkbox" checked={props.value} onChange={props.handleChange}></input>
-        {props.label}
-      </label>
-    </div>
+    <label className={'labeled-checkbox'}>
+      <input
+        type="checkbox"
+        checked={props.value}
+        onChange={props.handleChange}
+      ></input>
+      {props.label}
+    </label>
   )
 }

--- a/src/style.css
+++ b/src/style.css
@@ -34,8 +34,20 @@ body {
   justify-content: center;
   display: flex;
   flex-wrap: wrap;
-  gap: 0rem 1rem;
+  gap: 0 0;
+  accent-color: rgb(210, 129, 0);
 }
+
+.labeled-checkbox {
+  display: block;
+  width: 5.5rem;
+  padding: 0.25rem;
+  transition: background-color 0.1s ease-out;
+}
+.labeled-checkbox:hover {
+  background: rgb(255, 220, 165, 0.5);
+}
+
 .prefuctures-checkbox > div {
   flex-basis: 5.5rem;
 }

--- a/src/style.css
+++ b/src/style.css
@@ -3,14 +3,17 @@ body {
 }
 
 .header {
-  background: rgb(197, 197, 197);
+  background: rgb(65, 65, 65);
   text-align: center;
-  padding: 1rem;
+  padding: 1.5rem;
   position: sticky;
+  border-bottom: solid rgb(196, 196, 196) 0.125rem;
 }
 
-.header > * {
+.header > h1 {
+  font-size: 1.25rem;
   margin: 0;
+  color: rgb(226, 226, 226);
 }
 
 .container {

--- a/src/style.css
+++ b/src/style.css
@@ -1,5 +1,6 @@
 body {
   margin: 0;
+  background-color: whitesmoke;
 }
 
 .header {


### PR DESCRIPTION
+ 背景色の調整
+ チェックボックスの当たり判定を拡大
+ チェックボックスホバー時にインタラクト

チェックボックス周りはクリックしたつもりがクリックできていなかったときのイライラを減らすため。